### PR TITLE
Watch-based approach for handling crashlooping pods.

### DIFF
--- a/pkg/restarter/types.go
+++ b/pkg/restarter/types.go
@@ -1,6 +1,7 @@
 package restarter
 
 import (
+	"context"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,6 +35,12 @@ type Controller struct {
 	hasSynced         cache.InformerSynced
 	stopCh            <-chan struct{}
 	serviceDependants *ServiceDependants
-	retries           int
-	backoff           time.Duration
+	watchDuration     time.Duration
+	cancelFn          map[string]context.CancelFunc
+	contextCh         chan contextMessage
+}
+
+type contextMessage struct {
+	key      string
+	cancelFn context.CancelFunc
 }


### PR DESCRIPTION
I have tested the following scenarios.

1. Normal happy path. Etcd goes down and comes back.
1. Etcd goes down. Comes back. Goes down again before the watch-duration is over. 
1. Etcd goes down. Comes back. Goes down again and comes back again before the earlier watch-duration is over.
1. Etcd goes down. Comes back. Dep-controller goes down before watch duration is over with some pods still in `CrashloopBackoff`. Dep-controller comesback again to shoot any remaining pods in `CrashloopBackoff`.